### PR TITLE
RD-2097 Publish from Pages tab to Roxhill main site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,128 @@
-[![Gem Version](https://img.shields.io/gem/v/jekyll-admin.svg)](https://rubygems.org/gems/jekyll-admin)
-[![Build Status](https://travis-ci.org/jekyll/jekyll-admin.svg?branch=master)](https://travis-ci.org/jekyll/jekyll-admin)
-[![Build status](https://ci.appveyor.com/api/projects/status/biop1r6ae524xlm2/branch/master?svg=true)](https://ci.appveyor.com/project/benbalter/jekyll-admin/branch/master)
-[![Coverage Status](https://coveralls.io/repos/github/jekyll/jekyll-admin/badge.svg?branch=master)](https://coveralls.io/github/jekyll/jekyll-admin?branch=master)
-[![NPM Dependencies](https://david-dm.org/jekyll/jekyll-admin.svg)](https://david-dm.org/jekyll/jekyll-admin)
 
-A Jekyll plugin that provides users with a traditional CMS-style graphical interface to author content and administer Jekyll sites. The project is divided into two parts. A Ruby-based HTTP API that handles Jekyll and filesystem operations, and a JavaScript-based front end, built on that API.
+# Roxhill's marketing site
 
-![screenshot of Jekyll Admin](/screenshot.png)
+Roxhill's main site is served via Amazon Cloudfront out of an S3 bucket named `roxhillmedia.com` with a staging version and admin page served from a container in an EC2 instance. The homepage is generated from the files in _this_ repository but the code completing the _container_ is found on the `marketing` branch of the main `roxhill` repository. Every change to the master branch of the marketing site causes the container to be redeployed.
 
-## Installation
+The site uses the Ruby-based tool [Jekyll](https://jekyllrb.com). This fork of the Jekyll Admin plugin adds publish functionality.
 
-Refer to the [installing plugins](https://jekyllrb.com/docs/plugins/#installing-a-plugin) section of Jekyll's documentation and install the `jekyll-admin` plugin as you would any other plugin. Here's the short version:
+#### Principles
 
-1.  Add the following to your site's Gemfile:
+Jekyll-related images are stored in the AWS North Virginia region. The images are:
 
-    ```ruby
-    gem 'jekyll-admin', group: :jekyll_plugins
-    ```
+* `roxhill/jekyll-proxy:prod` _(last pushed in 2017)._
+* `roxhill/marketing-src:prod`
+  This is the constantly updated site. There are now 1870 images in the repository. Previously Amazon applied a limit of 1,000 to the number of images in a repository but this has since been increased to **10,000**.
+* `roxhill/jekyll:prod` _(last updated September 2019)._
+  The image is deployed from the `jekyll-admin` repository in GitHub.
 
-2.  Run `bundle install`
+The marketing site is driven by changes to the master branch of the `roxhill/marketing` repository. The `/.circleci/config.yml` file manifests the following steps:
 
-## Usage
+1. GitHub signals CircleCI to checkout the repository and login to AWS
+2. The Roxhill `roxhill/jekyll:prod` image is used to build a new version of the site with the admin plugin attached
+3. Most files that have `.html` extensions are changed so that those extensions are not included
+4. The files are then synced to S3 in the `roxhillmedia.com` bucket
+5. Specific redirects described in `/_data/redirects.yml` are actioned on S3 via the AWS S3 API.
+6. Amazon Cloudfront is instructed to invalidate its cache
+7. A new marketing-src image is built
+8. A new marketing-src image is pushed to the Amazon ECS repository
 
-1.  Start Jekyll as you would normally (`bundle exec jekyll serve`)
-2.  Navigate to `http://localhost:4000/admin` to access the administrative interface
+The CircleCI part takes roughly 3 minutes to complete.
 
-## Options
+Because the files are served out of S3 there is no automatic restart of the executing task in AWS. ECS has a "Cluster" named `jekyll-cluster-1709281557` of a single EC2-launched task (the actual instance is listed under the `ECS Instances` tab). The containers are listed under the `Tasks` tab by clicking on the ID for the single task. `nginx` and `jekyll` should both be running but `src` will not be. Clicking the task will show when it restarted.
 
-Jekyll Admin related options can be specified in `_config.yml`
-under a key called `jekyll_admin`. Currently it has only one option `hidden_links`
-which is for hiding unwanted links on the sidebar. The following keys under `hidden_links` can be used in order to hide default links;
+#### Ruby Setup
 
-```yaml
-jekyll_admin:
-  hidden_links:
-    - posts
-    - pages
-    - staticfiles
-    - datafiles
-    - configuration
+To setup your system to begin development follow the instructions for your system at https://jekyllrb.com/docs/installation/#requirements.
+
+For the Mac the steps begin with getting the command-line tools locally. With luck, they are already present on the system:
+
+```
+$ xcode-select --install
+xcode-select: error: command line tools are already installed, use "Software Update" to install updates
 ```
 
-## Contributing
+Then get a recent version of Ruby. The `New Starter : Setup` instructions on the Roxhill Wiki describe how to get Homebrew but the command is included below if this is yet to be done:
 
-Interested in contributing to Jekyll Admin? We’d love your help. Jekyll Admin is an open source project, built one contribution at a time by users like you. See [the contributing instructions](.github/CONTRIBUTING.md), and [the development docs](http://jekyll.github.io/jekyll-admin/development/) for more information.
+```
+# Install Homebrew if it wasn't done with setup
+# /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+$ brew install ruby
+...
+$ echo 'export PATH="/usr/local/opt/ruby/bin:$PATH"' >> ~/.bash_profile
+```
 
-## License
+At this point relaunch your terminal to make the updates to the `.bash_profile` take effect. Get the newly installed Ruby version and update the PATH again, this time with the future gem path using only the major.minor.0 portion of the Ruby version.
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+```
+$ ruby -v
+ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin18]
+$ echo 'export PATH="$HOME/.gem/ruby/2.6.0/bin:$PATH"' >> ~/.bash_profile
+```
+
+Restart the terminal again. Because macOS already has an older version of Ruby installed with the OS, it isn't recommended to try installing Bundler and Jekyll globally. Doing so gives an error like `"bundle" from bundler conflicts with /usr/local/lib/ruby/gems/2.6.0/bin/bundle`. However, in variance with the printed instructions you still need `sudo` to install Jekyll to avoid `Permission denied @ rb_sysopen` errors. Note a specific version of Bundler is required.
+
+```
+$ sudo gem install --user-install bundler -v1.17
+$ sudo gem install --user-install jekyll
+...
+Done installing documentation for public_suffix, addressable, colorator, http_parser.rb, eventmachine, em-websocket, concurrent-ruby, i18n, ffi, sassc, jekyll-sass-converter, rb-fsevent, rb-inotify, listen, jekyll-watch, kramdown, kramdown-parser-gfm, liquid, mercenary, forwardable-extended, pathutil, rouge, safe_yaml, unicode-display_width, terminal-table, jekyll after 24 seconds
+26 gems installed
+```
+
+Jekyll's admin plugin requires Node but some of the dependencies aren't available for the latest version. An earlier version of this will need to be installed too, which won't be symlinked because it's a variant install.
+
+```
+brew install node@10
+echo 'export PATH="/usr/local/opt/node@10/bin:$PATH"' >> ~/.bash_profile
+```
+
+#### Development Setup
+
+The following command checks out the marketing branch of the main repository, the locally-forked `jekyll-admin` plugin and the marketing repository (which should be renamed `site` to match the symbolic link in the plugin).
+
+```
+$ git clone -b marketing git@github.com:roxhill/roxhill.git roxhill-marketing
+$ git clone git@github.com:roxhill/jekyll-admin.git jekyll-admin
+$ git clone git@github.com:roxhill/marketing.git site
+```
+
+If desired, start and stop the Docker Compose development environment from inside the `roxhill-marketing` repo:
+
+```
+# Start the dev environment.
+# Requires a working AWS login, using roxhillapi:/ops/bin/local/login
+$ ./start-dev-env
+
+# Stop the dev environment.
+$ ./stop-dev-env
+```
+
+When running, the public site should be visible on http://127.0.0.1:4000. The admin page has "admin" appended, i.e. http://127.0.0.1:4000/admin (this principle is mirrored on the live staging site at https://marketing.roxhillmedia.com/admin after login. Everyone shares the same login to the admin site with credentials available from the team). In general `Save` buttons commit a page to the staging site, and `Publish` commits to the public site.
+
+To make changes to the admin panels follow the instructions in https://jekyll.github.io/jekyll-admin/development/. Enter the `jekyll-admin` repo and do the following commands. These will build a local `_site` directory inside the repo from the files in the `site` checkout described above.
+
+```
+$ script/bootstrap
+$ script/build
+$ script/test-server
+```
+
+**Note that deleting or publishing from this local checkout will still apply git commands that MODIFY THE MAIN SITE. Work network-isolated or take other precautions.**
+
+#### Failure scenarios
+
+##### “Marketing site is not working at all” and marketing.roxhillmedia.com returns 502 or similar
+
+EC2 will occasionally restart the container, and that’s why it needs the `src` image. However, the volume is preserved during the restart so saved changes are still there after the machine has booted up again.
+
+##### Deleting a page fails specifying a plausible but not real filename
+
+For example:
+
+```
+/usr/local/lib/ruby/gems/2.6.0/gems/jekyll-3.8.6/lib/jekyll/reader.rb:42: warning: conflicting chdir during another chdir block
+             Error: No such file or directory @ rb_sysopen - /Users/tony/Documents/jekyll-admin/spec/fixtures/site/insight-and-events/tools
+             Error: Run jekyll build --trace for more information.
+```
+
+This is under investigation but appears to be a race condition. See https://github.com/jekyll/jekyll-admin/issues/289#issuecomment-278365937.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -95,9 +95,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
       "dev": true
     },
     "babel-cli": {
@@ -712,7 +712,8 @@
                           "version": "1.1.3",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
                           "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
-                          "dev": true
+                          "dev": true,
+                          "optional": true
                         }
                       }
                     },
@@ -756,13 +757,15 @@
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                       "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "kind-of": {
                       "version": "3.2.2",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "is-buffer": "^1.1.5"
                       },
@@ -771,7 +774,8 @@
                           "version": "1.1.6",
                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-                          "dev": true
+                          "dev": true,
+                          "optional": true
                         }
                       }
                     },
@@ -885,6 +889,7 @@
                   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
                   "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "remove-trailing-separator": "^1.0.1"
                   },
@@ -893,7 +898,8 @@
                       "version": "1.1.0",
                       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
                       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     }
                   }
                 }
@@ -928,7 +934,8 @@
                   "version": "2.1.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "aproba": {
                   "version": "1.2.0",
@@ -952,13 +959,15 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
                   "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "brace-expansion": {
                   "version": "1.1.11",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
                   "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
@@ -975,19 +984,22 @@
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                   "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                   "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
@@ -1118,7 +1130,8 @@
                   "version": "2.0.3",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "ini": {
                   "version": "1.3.5",
@@ -1132,6 +1145,7 @@
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
                   }
@@ -1148,6 +1162,7 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   }
@@ -1156,13 +1171,15 @@
                   "version": "0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "minipass": {
                   "version": "2.2.4",
                   "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
                   "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "safe-buffer": "^5.1.1",
                     "yallist": "^3.0.0"
@@ -1183,6 +1200,7 @@
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "minimist": "0.0.8"
                   }
@@ -1278,7 +1296,8 @@
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                   "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "object-assign": {
                   "version": "4.1.1",
@@ -1292,6 +1311,7 @@
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "wrappy": "1"
                   }
@@ -1387,7 +1407,8 @@
                   "version": "5.1.1",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
                   "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "safer-buffer": {
                   "version": "2.1.2",
@@ -1429,6 +1450,7 @@
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -1450,6 +1472,7 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   }
@@ -1498,13 +1521,15 @@
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "yallist": {
                   "version": "3.0.2",
                   "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
                   "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -1513,6 +1538,7 @@
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
               "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-glob": "^2.0.0"
               }
@@ -1521,7 +1547,8 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "is-binary-path": {
               "version": "1.0.1",
@@ -1547,6 +1574,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "is-extglob": "^1.0.0"
               },
@@ -1555,7 +1583,8 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                   "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -1604,13 +1633,15 @@
                       "version": "4.0.0",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
                       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "array-unique": {
                       "version": "0.3.2",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
                       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "braces": {
                       "version": "2.3.2",
@@ -1643,6 +1674,7 @@
                           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "is-extendable": "^0.1.0"
                           },
@@ -1651,7 +1683,8 @@
                               "version": "0.1.1",
                               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                               "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         },
@@ -1673,6 +1706,7 @@
                               "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                               "dev": true,
+                              "optional": true,
                               "requires": {
                                 "kind-of": "^3.0.2"
                               },
@@ -1682,6 +1716,7 @@
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "is-buffer": "^1.1.5"
                                   },
@@ -1690,7 +1725,8 @@
                                       "version": "1.1.6",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                                       "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-                                      "dev": true
+                                      "dev": true,
+                                      "optional": true
                                     }
                                   }
                                 }
@@ -1700,7 +1736,8 @@
                               "version": "1.6.1",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
                               "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             },
                             "to-regex-range": {
                               "version": "2.1.1",
@@ -1719,7 +1756,8 @@
                           "version": "3.0.1",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
                           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                          "dev": true
+                          "dev": true,
+                          "optional": true
                         },
                         "repeat-element": {
                           "version": "1.1.3",
@@ -1880,6 +1918,7 @@
                       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
                       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "is-descriptor": "^1.0.2",
                         "isobject": "^3.0.1"
@@ -1890,6 +1929,7 @@
                           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "is-accessor-descriptor": "^1.0.0",
                             "is-data-descriptor": "^1.0.0",
@@ -1901,6 +1941,7 @@
                               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                               "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
                               "dev": true,
+                              "optional": true,
                               "requires": {
                                 "kind-of": "^6.0.0"
                               }
@@ -1910,6 +1951,7 @@
                               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                               "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
                               "dev": true,
+                              "optional": true,
                               "requires": {
                                 "kind-of": "^6.0.0"
                               }
@@ -1920,7 +1962,8 @@
                           "version": "3.0.1",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
                           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                          "dev": true
+                          "dev": true,
+                          "optional": true
                         }
                       }
                     },
@@ -1929,6 +1972,7 @@
                       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "assign-symbols": "^1.0.0",
                         "is-extendable": "^1.0.1"
@@ -1938,13 +1982,15 @@
                           "version": "1.0.0",
                           "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
                           "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-                          "dev": true
+                          "dev": true,
+                          "optional": true
                         },
                         "is-extendable": {
                           "version": "1.0.1",
                           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "is-plain-object": "^2.0.4"
                           },
@@ -1954,6 +2000,7 @@
                               "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
                               "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
                               "dev": true,
+                              "optional": true,
                               "requires": {
                                 "isobject": "^3.0.1"
                               },
@@ -1962,7 +2009,8 @@
                                   "version": "3.0.1",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
                                   "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                                  "dev": true
+                                  "dev": true,
+                                  "optional": true
                                 }
                               }
                             }
@@ -2177,6 +2225,7 @@
                           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "is-extendable": "^0.1.0"
                           },
@@ -2185,7 +2234,8 @@
                               "version": "0.1.1",
                               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                               "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         }
@@ -2196,6 +2246,7 @@
                       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
                       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "map-cache": "^0.2.2"
                       },
@@ -2204,7 +2255,8 @@
                           "version": "0.2.2",
                           "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
                           "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-                          "dev": true
+                          "dev": true,
+                          "optional": true
                         }
                       }
                     },
@@ -2212,7 +2264,8 @@
                       "version": "6.0.2",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
                       "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "nanomatch": {
                       "version": "1.2.13",
@@ -2248,6 +2301,7 @@
                       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
                       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "isobject": "^3.0.1"
                       },
@@ -2256,7 +2310,8 @@
                           "version": "3.0.1",
                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
                           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                          "dev": true
+                          "dev": true,
+                          "optional": true
                         }
                       }
                     },
@@ -2265,6 +2320,7 @@
                       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
                       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "extend-shallow": "^3.0.2",
                         "safe-regex": "^1.1.0"
@@ -2275,6 +2331,7 @@
                           "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
                           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "ret": "~0.1.10"
                           },
@@ -2283,7 +2340,8 @@
                               "version": "0.1.15",
                               "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
                               "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         }
@@ -2294,6 +2352,7 @@
                       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
                       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "base": "^0.11.1",
                         "debug": "^2.2.0",
@@ -2310,6 +2369,7 @@
                           "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
                           "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "cache-base": "^1.0.1",
                             "class-utils": "^0.3.5",
@@ -2325,6 +2385,7 @@
                               "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
                               "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
                               "dev": true,
+                              "optional": true,
                               "requires": {
                                 "collection-visit": "^1.0.0",
                                 "component-emitter": "^1.2.1",
@@ -2342,6 +2403,7 @@
                                   "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
                                   "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "map-visit": "^1.0.0",
                                     "object-visit": "^1.0.0"
@@ -2352,6 +2414,7 @@
                                       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
                                       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "object-visit": "^1.0.0"
                                       }
@@ -2361,6 +2424,7 @@
                                       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
                                       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "isobject": "^3.0.0"
                                       }
@@ -2371,13 +2435,15 @@
                                   "version": "2.0.6",
                                   "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
                                   "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-                                  "dev": true
+                                  "dev": true,
+                                  "optional": true
                                 },
                                 "has-value": {
                                   "version": "1.0.0",
                                   "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
                                   "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "get-value": "^2.0.6",
                                     "has-values": "^1.0.0",
@@ -2389,6 +2455,7 @@
                                       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
                                       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "is-number": "^3.0.0",
                                         "kind-of": "^4.0.0"
@@ -2399,6 +2466,7 @@
                                           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                                           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                                           "dev": true,
+                                          "optional": true,
                                           "requires": {
                                             "kind-of": "^3.0.2"
                                           },
@@ -2408,6 +2476,7 @@
                                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                               "dev": true,
+                                              "optional": true,
                                               "requires": {
                                                 "is-buffer": "^1.1.5"
                                               },
@@ -2416,7 +2485,8 @@
                                                   "version": "1.1.6",
                                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                                                   "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-                                                  "dev": true
+                                                  "dev": true,
+                                                  "optional": true
                                                 }
                                               }
                                             }
@@ -2427,6 +2497,7 @@
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                                           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                                           "dev": true,
+                                          "optional": true,
                                           "requires": {
                                             "is-buffer": "^1.1.5"
                                           },
@@ -2435,7 +2506,8 @@
                                               "version": "1.1.6",
                                               "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                                               "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-                                              "dev": true
+                                              "dev": true,
+                                              "optional": true
                                             }
                                           }
                                         }
@@ -2448,6 +2520,7 @@
                                   "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
                                   "integrity": "sha1-ca5KiPD+77v1LR6mBPP7MV67YnQ=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "extend-shallow": "^2.0.1",
                                     "is-extendable": "^0.1.1",
@@ -2459,13 +2532,15 @@
                                       "version": "0.1.1",
                                       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                                       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-                                      "dev": true
+                                      "dev": true,
+                                      "optional": true
                                     },
                                     "is-plain-object": {
                                       "version": "2.0.4",
                                       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
                                       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "isobject": "^3.0.1"
                                       }
@@ -2475,6 +2550,7 @@
                                       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
                                       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "extend-shallow": "^3.0.0"
                                       },
@@ -2484,6 +2560,7 @@
                                           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
                                           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                                           "dev": true,
+                                          "optional": true,
                                           "requires": {
                                             "assign-symbols": "^1.0.0",
                                             "is-extendable": "^1.0.1"
@@ -2493,13 +2570,15 @@
                                               "version": "1.0.0",
                                               "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
                                               "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-                                              "dev": true
+                                              "dev": true,
+                                              "optional": true
                                             },
                                             "is-extendable": {
                                               "version": "1.0.1",
                                               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                                               "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
                                               "dev": true,
+                                              "optional": true,
                                               "requires": {
                                                 "is-plain-object": "^2.0.4"
                                               }
@@ -2515,6 +2594,7 @@
                                   "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
                                   "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "kind-of": "^3.0.2"
                                   },
@@ -2524,6 +2604,7 @@
                                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "is-buffer": "^1.1.5"
                                       },
@@ -2532,7 +2613,8 @@
                                           "version": "1.1.6",
                                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                                           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-                                          "dev": true
+                                          "dev": true,
+                                          "optional": true
                                         }
                                       }
                                     }
@@ -2543,6 +2625,7 @@
                                   "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
                                   "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "arr-union": "^3.1.0",
                                     "get-value": "^2.0.6",
@@ -2554,19 +2637,22 @@
                                       "version": "3.1.0",
                                       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
                                       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-                                      "dev": true
+                                      "dev": true,
+                                      "optional": true
                                     },
                                     "is-extendable": {
                                       "version": "0.1.1",
                                       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                                       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-                                      "dev": true
+                                      "dev": true,
+                                      "optional": true
                                     },
                                     "set-value": {
                                       "version": "0.4.3",
                                       "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
                                       "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "extend-shallow": "^2.0.1",
                                         "is-extendable": "^0.1.1",
@@ -2579,6 +2665,7 @@
                                           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
                                           "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
                                           "dev": true,
+                                          "optional": true,
                                           "requires": {
                                             "isobject": "^3.0.1"
                                           }
@@ -2592,6 +2679,7 @@
                                   "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
                                   "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "has-value": "^0.3.1",
                                     "isobject": "^3.0.0"
@@ -2602,6 +2690,7 @@
                                       "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                                       "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "get-value": "^2.0.3",
                                         "has-values": "^0.1.4",
@@ -2612,13 +2701,15 @@
                                           "version": "0.1.4",
                                           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
                                           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-                                          "dev": true
+                                          "dev": true,
+                                          "optional": true
                                         },
                                         "isobject": {
                                           "version": "2.1.0",
                                           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
                                           "dev": true,
+                                          "optional": true,
                                           "requires": {
                                             "isarray": "1.0.0"
                                           },
@@ -2627,7 +2718,8 @@
                                               "version": "1.0.0",
                                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                                               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                                              "dev": true
+                                              "dev": true,
+                                              "optional": true
                                             }
                                           }
                                         }
@@ -2642,6 +2734,7 @@
                               "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
                               "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
                               "dev": true,
+                              "optional": true,
                               "requires": {
                                 "arr-union": "^3.1.0",
                                 "define-property": "^0.2.5",
@@ -2653,13 +2746,15 @@
                                   "version": "3.1.0",
                                   "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
                                   "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-                                  "dev": true
+                                  "dev": true,
+                                  "optional": true
                                 },
                                 "define-property": {
                                   "version": "0.2.5",
                                   "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                                   "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "is-descriptor": "^0.1.0"
                                   },
@@ -2669,6 +2764,7 @@
                                       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
                                       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "is-accessor-descriptor": "^0.1.6",
                                         "is-data-descriptor": "^0.1.4",
@@ -2680,6 +2776,7 @@
                                           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                                           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                                           "dev": true,
+                                          "optional": true,
                                           "requires": {
                                             "kind-of": "^3.0.2"
                                           },
@@ -2689,6 +2786,7 @@
                                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                               "dev": true,
+                                              "optional": true,
                                               "requires": {
                                                 "is-buffer": "^1.1.5"
                                               },
@@ -2697,7 +2795,8 @@
                                                   "version": "1.1.6",
                                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                                                   "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-                                                  "dev": true
+                                                  "dev": true,
+                                                  "optional": true
                                                 }
                                               }
                                             }
@@ -2708,6 +2807,7 @@
                                           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                                           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                                           "dev": true,
+                                          "optional": true,
                                           "requires": {
                                             "kind-of": "^3.0.2"
                                           },
@@ -2717,6 +2817,7 @@
                                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                               "dev": true,
+                                              "optional": true,
                                               "requires": {
                                                 "is-buffer": "^1.1.5"
                                               },
@@ -2725,7 +2826,8 @@
                                                   "version": "1.1.6",
                                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                                                   "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-                                                  "dev": true
+                                                  "dev": true,
+                                                  "optional": true
                                                 }
                                               }
                                             }
@@ -2735,7 +2837,8 @@
                                           "version": "5.1.0",
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                                           "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
-                                          "dev": true
+                                          "dev": true,
+                                          "optional": true
                                         }
                                       }
                                     }
@@ -2746,6 +2849,7 @@
                                   "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
                                   "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "define-property": "^0.2.5",
                                     "object-copy": "^0.1.0"
@@ -2756,6 +2860,7 @@
                                       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
                                       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "copy-descriptor": "^0.1.0",
                                         "define-property": "^0.2.5",
@@ -2766,13 +2871,15 @@
                                           "version": "0.1.1",
                                           "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
                                           "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-                                          "dev": true
+                                          "dev": true,
+                                          "optional": true
                                         },
                                         "kind-of": {
                                           "version": "3.2.2",
                                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                           "dev": true,
+                                          "optional": true,
                                           "requires": {
                                             "is-buffer": "^1.1.5"
                                           },
@@ -2781,7 +2888,8 @@
                                               "version": "1.1.6",
                                               "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                                               "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-                                              "dev": true
+                                              "dev": true,
+                                              "optional": true
                                             }
                                           }
                                         }
@@ -2795,13 +2903,15 @@
                               "version": "1.2.1",
                               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
                               "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             },
                             "define-property": {
                               "version": "1.0.0",
                               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                               "dev": true,
+                              "optional": true,
                               "requires": {
                                 "is-descriptor": "^1.0.0"
                               },
@@ -2811,6 +2921,7 @@
                                   "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                                   "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "is-accessor-descriptor": "^1.0.0",
                                     "is-data-descriptor": "^1.0.0",
@@ -2822,6 +2933,7 @@
                                       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                                       "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "kind-of": "^6.0.0"
                                       }
@@ -2831,6 +2943,7 @@
                                       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                                       "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "kind-of": "^6.0.0"
                                       }
@@ -2843,13 +2956,15 @@
                               "version": "3.0.1",
                               "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
                               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             },
                             "mixin-deep": {
                               "version": "1.3.1",
                               "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
                               "integrity": "sha1-pJ5yaNzhoNlpjkUybFYm3zVD0P4=",
                               "dev": true,
+                              "optional": true,
                               "requires": {
                                 "for-in": "^1.0.2",
                                 "is-extendable": "^1.0.1"
@@ -2859,13 +2974,15 @@
                                   "version": "1.0.2",
                                   "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
                                   "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-                                  "dev": true
+                                  "dev": true,
+                                  "optional": true
                                 },
                                 "is-extendable": {
                                   "version": "1.0.1",
                                   "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                                   "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "is-plain-object": "^2.0.4"
                                   },
@@ -2875,6 +2992,7 @@
                                       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
                                       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "isobject": "^3.0.1"
                                       }
@@ -2887,7 +3005,8 @@
                               "version": "0.1.1",
                               "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
                               "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         },
@@ -2896,6 +3015,7 @@
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "ms": "2.0.0"
                           },
@@ -2904,7 +3024,8 @@
                               "version": "2.0.0",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         },
@@ -2913,6 +3034,7 @@
                           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "is-descriptor": "^0.1.0"
                           },
@@ -2922,6 +3044,7 @@
                               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
                               "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
                               "dev": true,
+                              "optional": true,
                               "requires": {
                                 "is-accessor-descriptor": "^0.1.6",
                                 "is-data-descriptor": "^0.1.4",
@@ -2933,6 +3056,7 @@
                                   "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                                   "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "kind-of": "^3.0.2"
                                   },
@@ -2942,6 +3066,7 @@
                                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "is-buffer": "^1.1.5"
                                       },
@@ -2950,7 +3075,8 @@
                                           "version": "1.1.6",
                                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                                           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-                                          "dev": true
+                                          "dev": true,
+                                          "optional": true
                                         }
                                       }
                                     }
@@ -2961,6 +3087,7 @@
                                   "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                                   "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                                   "dev": true,
+                                  "optional": true,
                                   "requires": {
                                     "kind-of": "^3.0.2"
                                   },
@@ -2970,6 +3097,7 @@
                                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                       "dev": true,
+                                      "optional": true,
                                       "requires": {
                                         "is-buffer": "^1.1.5"
                                       },
@@ -2978,7 +3106,8 @@
                                           "version": "1.1.6",
                                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
                                           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-                                          "dev": true
+                                          "dev": true,
+                                          "optional": true
                                         }
                                       }
                                     }
@@ -2988,7 +3117,8 @@
                                   "version": "5.1.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                                   "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
-                                  "dev": true
+                                  "dev": true,
+                                  "optional": true
                                 }
                               }
                             }
@@ -2999,6 +3129,7 @@
                           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "is-extendable": "^0.1.0"
                           },
@@ -3007,7 +3138,8 @@
                               "version": "0.1.1",
                               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                               "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         },
@@ -3015,13 +3147,15 @@
                           "version": "0.2.2",
                           "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
                           "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-                          "dev": true
+                          "dev": true,
+                          "optional": true
                         },
                         "source-map-resolve": {
                           "version": "0.5.2",
                           "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
                           "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "atob": "^2.1.1",
                             "decode-uri-component": "^0.2.0",
@@ -3034,31 +3168,36 @@
                               "version": "2.1.2",
                               "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
                               "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             },
                             "decode-uri-component": {
                               "version": "0.2.0",
                               "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
                               "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             },
                             "resolve-url": {
                               "version": "0.2.1",
                               "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
                               "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             },
                             "source-map-url": {
                               "version": "0.4.0",
                               "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
                               "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             },
                             "urix": {
                               "version": "0.1.0",
                               "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
                               "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         },
@@ -3066,7 +3205,8 @@
                           "version": "3.1.1",
                           "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
                           "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
-                          "dev": true
+                          "dev": true,
+                          "optional": true
                         }
                       }
                     },
@@ -3075,6 +3215,7 @@
                       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
                       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "define-property": "^2.0.2",
                         "extend-shallow": "^3.0.2",
@@ -3087,6 +3228,7 @@
                           "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
                           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
                           "dev": true,
+                          "optional": true,
                           "requires": {
                             "ret": "~0.1.10"
                           },
@@ -3095,7 +3237,8 @@
                               "version": "0.1.15",
                               "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
                               "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
-                              "dev": true
+                              "dev": true,
+                              "optional": true
                             }
                           }
                         }
@@ -3144,7 +3287,8 @@
                       "version": "5.1.2",
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "string_decoder": {
                       "version": "1.1.1",
@@ -11155,15 +11299,6 @@
         "inherits": "~2.0.0"
       }
     },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "http://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x"
-      }
-    },
     "brace": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/brace/-/brace-0.9.1.tgz",
@@ -11477,7 +11612,8 @@
                   "version": "2.1.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "aproba": {
                   "version": "1.1.1",
@@ -11536,7 +11672,8 @@
                   "version": "0.4.2",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                   "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "bcrypt-pbkdf": {
                   "version": "1.0.1",
@@ -11553,6 +11690,7 @@
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
                   "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "inherits": "~2.0.0"
                   }
@@ -11562,6 +11700,7 @@
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "hoek": "2.x.x"
                   }
@@ -11571,6 +11710,7 @@
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                   "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
@@ -11580,7 +11720,8 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
                   "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "caseless": {
                   "version": "0.12.0",
@@ -11600,13 +11741,15 @@
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                   "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "delayed-stream": "~1.0.0"
                   }
@@ -11615,19 +11758,22 @@
                   "version": "0.0.1",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                   "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "cryptiles": {
                   "version": "2.0.5",
@@ -11679,7 +11825,8 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "delegates": {
                   "version": "1.0.0",
@@ -11709,7 +11856,8 @@
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                   "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
@@ -11734,13 +11882,15 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                   "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "fstream": {
                   "version": "1.0.11",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
                   "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "graceful-fs": "^4.1.2",
                     "inherits": "~2.0.0",
@@ -11801,6 +11951,7 @@
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                   "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "fs.realpath": "^1.0.0",
                     "inflight": "^1.0.4",
@@ -11814,7 +11965,8 @@
                   "version": "4.1.11",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
                   "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "har-schema": {
                   "version": "1.0.5",
@@ -11858,7 +12010,8 @@
                   "version": "2.16.3",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                   "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "http-signature": {
                   "version": "1.1.1",
@@ -11877,6 +12030,7 @@
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "once": "^1.3.0",
                     "wrappy": "1"
@@ -11886,7 +12040,8 @@
                   "version": "2.0.3",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "ini": {
                   "version": "1.3.4",
@@ -11900,6 +12055,7 @@
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
                   }
@@ -11915,7 +12071,8 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "isstream": {
                   "version": "0.1.2",
@@ -11998,13 +12155,15 @@
                   "version": "1.27.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
                   "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "mime-types": {
                   "version": "2.1.15",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
                   "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "mime-db": "~1.27.0"
                   }
@@ -12014,6 +12173,7 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   }
@@ -12022,13 +12182,15 @@
                   "version": "0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "mkdirp": {
                   "version": "0.5.1",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "minimist": "0.0.8"
                   }
@@ -12093,7 +12255,8 @@
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                   "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
@@ -12114,6 +12277,7 @@
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "wrappy": "1"
                   }
@@ -12147,7 +12311,8 @@
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                   "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "performance-now": {
                   "version": "0.2.0",
@@ -12160,7 +12325,8 @@
                   "version": "1.0.7",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "punycode": {
                   "version": "1.4.1",
@@ -12203,6 +12369,7 @@
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
                   "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "buffer-shims": "~1.0.0",
                     "core-util-is": "~1.0.0",
@@ -12249,6 +12416,7 @@
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
                   "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "glob": "^7.0.5"
                   }
@@ -12257,7 +12425,8 @@
                   "version": "5.0.1",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
                   "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "semver": {
                   "version": "5.3.0",
@@ -12322,6 +12491,7 @@
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -12333,6 +12503,7 @@
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
                   "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "safe-buffer": "^5.0.1"
                   }
@@ -12349,6 +12520,7 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   }
@@ -12365,6 +12537,7 @@
                   "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
                   "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "block-stream": "*",
                     "fstream": "^1.0.2",
@@ -12426,7 +12599,8 @@
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "uuid": {
                   "version": "3.0.1",
@@ -12459,7 +12633,8 @@
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -15405,12 +15580,6 @@
         }
       }
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -15419,7 +15588,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -15710,7 +15879,8 @@
               "version": "2.7.0",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
               "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "acorn-globals": {
               "version": "1.0.9",
@@ -15726,7 +15896,8 @@
               "version": "0.3.2",
               "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
               "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "cssstyle": {
               "version": "0.2.37",
@@ -15817,13 +15988,15 @@
                       "version": "1.1.2",
                       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
                       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "type-check": {
                       "version": "0.3.2",
                       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "prelude-ls": "~1.1.2"
                       }
@@ -15917,6 +16090,7 @@
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "delayed-stream": "~1.0.0"
                   },
@@ -15925,7 +16099,8 @@
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     }
                   }
                 },
@@ -16088,7 +16263,8 @@
                       "version": "4.2.0",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
                       "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "sntp": {
                       "version": "2.0.2",
@@ -16118,7 +16294,8 @@
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "jsprim": {
                       "version": "1.4.1",
@@ -16137,7 +16314,8 @@
                           "version": "1.3.0",
                           "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
                           "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-                          "dev": true
+                          "dev": true,
+                          "optional": true
                         },
                         "json-schema": {
                           "version": "0.2.3",
@@ -16277,6 +16455,7 @@
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
                   "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "mime-db": "~1.30.0"
                   },
@@ -16285,7 +16464,8 @@
                       "version": "1.30.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
                       "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     }
                   }
                 },
@@ -16314,7 +16494,8 @@
                   "version": "5.1.1",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
                   "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "stringstream": {
                   "version": "0.0.5",
@@ -16361,6 +16542,7 @@
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
               "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "punycode": "^1.4.1"
               },
@@ -16369,7 +16551,8 @@
                   "version": "1.4.1",
                   "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
                   "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -16433,19 +16616,13 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
-      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -16977,24 +17154,15 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.4.tgz",
-          "integrity": "sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==",
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
-            "yallist": "^3.0.2"
+            "yallist": "^2.1.2"
           }
         }
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.x.x"
       }
     },
     "css-loader": {
@@ -21211,7 +21379,8 @@
                   "version": "2.1.1",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "aproba": {
                   "version": "1.1.1",
@@ -21270,7 +21439,8 @@
                   "version": "0.4.2",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                   "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "bcrypt-pbkdf": {
                   "version": "1.0.1",
@@ -21287,6 +21457,7 @@
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
                   "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "inherits": "~2.0.0"
                   }
@@ -21296,6 +21467,7 @@
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "hoek": "2.x.x"
                   }
@@ -21305,6 +21477,7 @@
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                   "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
@@ -21314,7 +21487,8 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
                   "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "caseless": {
                   "version": "0.12.0",
@@ -21334,13 +21508,15 @@
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                   "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "combined-stream": {
                   "version": "1.0.5",
                   "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "delayed-stream": "~1.0.0"
                   }
@@ -21349,19 +21525,22 @@
                   "version": "0.0.1",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "console-control-strings": {
                   "version": "1.1.0",
                   "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                   "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "core-util-is": {
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "cryptiles": {
                   "version": "2.0.5",
@@ -21413,7 +21592,8 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "delegates": {
                   "version": "1.0.0",
@@ -21443,7 +21623,8 @@
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                   "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "forever-agent": {
                   "version": "0.6.1",
@@ -21468,13 +21649,15 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                   "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "fstream": {
                   "version": "1.0.11",
                   "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
                   "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "graceful-fs": "^4.1.2",
                     "inherits": "~2.0.0",
@@ -21535,6 +21718,7 @@
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                   "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "fs.realpath": "^1.0.0",
                     "inflight": "^1.0.4",
@@ -21548,7 +21732,8 @@
                   "version": "4.1.11",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
                   "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "har-schema": {
                   "version": "1.0.5",
@@ -21592,7 +21777,8 @@
                   "version": "2.16.3",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                   "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "http-signature": {
                   "version": "1.1.1",
@@ -21611,6 +21797,7 @@
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "once": "^1.3.0",
                     "wrappy": "1"
@@ -21620,7 +21807,8 @@
                   "version": "2.0.3",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "ini": {
                   "version": "1.3.4",
@@ -21634,6 +21822,7 @@
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "number-is-nan": "^1.0.0"
                   }
@@ -21649,7 +21838,8 @@
                   "version": "1.0.0",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "isstream": {
                   "version": "0.1.2",
@@ -21732,13 +21922,15 @@
                   "version": "1.27.0",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
                   "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "mime-types": {
                   "version": "2.1.15",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
                   "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "mime-db": "~1.27.0"
                   }
@@ -21748,6 +21940,7 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                   "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "brace-expansion": "^1.1.7"
                   }
@@ -21756,13 +21949,15 @@
                   "version": "0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "mkdirp": {
                   "version": "0.5.1",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "minimist": "0.0.8"
                   }
@@ -21827,7 +22022,8 @@
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                   "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "oauth-sign": {
                   "version": "0.8.2",
@@ -21848,6 +22044,7 @@
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "wrappy": "1"
                   }
@@ -21881,7 +22078,8 @@
                   "version": "1.0.1",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                   "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "performance-now": {
                   "version": "0.2.0",
@@ -21894,7 +22092,8 @@
                   "version": "1.0.7",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "punycode": {
                   "version": "1.4.1",
@@ -21937,6 +22136,7 @@
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
                   "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "buffer-shims": "~1.0.0",
                     "core-util-is": "~1.0.0",
@@ -21983,6 +22183,7 @@
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
                   "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "glob": "^7.0.5"
                   }
@@ -21991,7 +22192,8 @@
                   "version": "5.0.1",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
                   "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "semver": {
                   "version": "5.3.0",
@@ -22056,6 +22258,7 @@
                   "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                   "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "code-point-at": "^1.0.0",
                     "is-fullwidth-code-point": "^1.0.0",
@@ -22067,6 +22270,7 @@
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
                   "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "safe-buffer": "^5.0.1"
                   }
@@ -22083,6 +22287,7 @@
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "ansi-regex": "^2.0.0"
                   }
@@ -22099,6 +22304,7 @@
                   "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
                   "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
                   "dev": true,
+                  "optional": true,
                   "requires": {
                     "block-stream": "*",
                     "fstream": "^1.0.2",
@@ -22160,7 +22366,8 @@
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 },
                 "uuid": {
                   "version": "3.0.1",
@@ -22193,7 +22400,8 @@
                   "version": "1.0.2",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -22663,9 +22871,9 @@
       "dev": true
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -22699,24 +22907,6 @@
         "globule": "^1.0.0"
       }
     },
-    "generate-function": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "dev": true,
-      "requires": {
-        "is-property": "^1.0.2"
-      }
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "^1.0.0"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -22739,9 +22929,9 @@
       }
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -22775,9 +22965,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "minimatch": {
@@ -22792,9 +22982,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
     "har-schema": {
@@ -22819,33 +23009,15 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "http://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
-      }
-    },
     "highlight.js": {
       "version": "9.12.0",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
       "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
     },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "http://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
-    },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
     "http-signature": {
@@ -22944,9 +23116,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "invert-kv": {
@@ -22960,15 +23132,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
     },
     "is-finite": {
       "version": "1.0.2",
@@ -22987,31 +23150,6 @@
       "requires": {
         "number-is-nan": "^1.0.0"
       }
-    },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true
-    },
-    "is-my-json-valid": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
-      "dev": true,
-      "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -26447,9 +26585,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
-      "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
       "dev": true
     },
     "js-tokens": {
@@ -27232,12 +27370,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsprim": {
@@ -28158,7 +28290,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -28187,9 +28319,9 @@
       "dev": true
     },
     "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
     "loose-envify": {
@@ -28224,7 +28356,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -28241,18 +28373,18 @@
       }
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.42.0"
       }
     },
     "minimatch": {
@@ -28267,7 +28399,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -28409,9 +28541,9 @@
       "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI="
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true
     },
     "nock": {
@@ -28541,46 +28673,18 @@
         "which": "1"
       },
       "dependencies": {
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          }
-        },
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
       }
     },
     "node-sass": {
-      "version": "4.8.3",
-      "resolved": "http://registry.npmjs.org/node-sass/-/node-sass-4.8.3.tgz",
-      "integrity": "sha512-tfFWhUsCk/Y19zarDcPo5xpj+IW3qCfOjVdHtYeG6S1CKbQOh1zqylnQK6cV3z9k80yxAnFX9Y+a9+XysDhhfg==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.10.0.tgz",
+      "integrity": "sha512-fDQJfXszw6vek63Fe/ldkYXmRYK/QS6NbvM3i5oEo9ntPDy4XX7BcKZyTKv+/kSSxRtXXc7l+MSwEmYc0CSy6Q==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -28596,9 +28700,9 @@
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.10.0",
-        "node-gyp": "^3.3.1",
+        "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
-        "request": "~2.79.0",
+        "request": "^2.88.0",
         "sass-graph": "^2.2.4",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
@@ -28614,13 +28718,13 @@
       }
     },
     "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
+        "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
@@ -29241,13 +29345,13 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -29256,7 +29360,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -29290,8 +29394,14 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-type": {
@@ -29313,7 +29423,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -29339,9 +29449,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "promise": {
@@ -29390,9 +29500,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
+      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
       "dev": true
     },
     "punycode": {
@@ -30064,7 +30174,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -30197,118 +30307,31 @@
       }
     },
     "request": {
-      "version": "2.79.0",
-      "resolved": "http://registry.npmjs.org/request/-/request-2.79.0.tgz",
-      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.6.0",
-        "aws4": "^1.2.1",
-        "caseless": "~0.11.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.0",
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~2.1.1",
-        "har-validator": "~2.0.6",
-        "hawk": "~3.1.3",
-        "http-signature": "~1.1.0",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.7",
-        "oauth-sign": "~0.8.1",
-        "qs": "~6.3.0",
-        "stringstream": "~0.0.4",
-        "tough-cookie": "~2.3.0",
-        "tunnel-agent": "~0.4.1",
-        "uuid": "^3.0.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.1",
-            "commander": "^2.9.0",
-            "is-my-json-valid": "^2.12.4",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-          "dev": true,
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        }
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "require-directory": {
@@ -30322,6 +30345,15 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
+      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "rimraf": {
       "version": "2.5.4",
@@ -30541,9 +30573,9 @@
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "set-blocking": {
@@ -30606,15 +30638,6 @@
         }
       }
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "http://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x"
-      }
-    },
     "sortablejs": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.4.2.tgz",
@@ -30622,7 +30645,7 @@
     },
     "source-map": {
       "version": "0.4.4",
-      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "dev": true,
       "requires": {
@@ -30630,9 +30653,9 @@
       }
     },
     "spdx-correct": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -30656,15 +30679,15 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -30707,15 +30730,9 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true
-    },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -30790,13 +30807,13 @@
       }
     },
     "tar": {
-      "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
       "dev": true,
       "requires": {
         "block-stream": "*",
-        "fstream": "^1.0.2",
+        "fstream": "^1.0.12",
         "inherits": "2"
       }
     },
@@ -30874,9 +30891,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -33008,7 +33025,8 @@
                       "version": "2.1.1",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "aproba": {
                       "version": "1.1.1",
@@ -33067,7 +33085,8 @@
                       "version": "0.4.2",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                       "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
@@ -33084,6 +33103,7 @@
                       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
                       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "inherits": "~2.0.0"
                       }
@@ -33093,6 +33113,7 @@
                       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "hoek": "2.x.x"
                       }
@@ -33102,6 +33123,7 @@
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                       "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
@@ -33111,7 +33133,8 @@
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
                       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "caseless": {
                       "version": "0.12.0",
@@ -33131,13 +33154,15 @@
                       "version": "1.1.0",
                       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "combined-stream": {
                       "version": "1.0.5",
                       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "delayed-stream": "~1.0.0"
                       }
@@ -33146,19 +33171,22 @@
                       "version": "0.0.1",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "console-control-strings": {
                       "version": "1.1.0",
                       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
                       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "core-util-is": {
                       "version": "1.0.2",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "cryptiles": {
                       "version": "2.0.5",
@@ -33210,7 +33238,8 @@
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "delegates": {
                       "version": "1.0.0",
@@ -33240,7 +33269,8 @@
                       "version": "1.0.2",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "forever-agent": {
                       "version": "0.6.1",
@@ -33265,13 +33295,15 @@
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "fstream": {
                       "version": "1.0.11",
                       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
                       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "graceful-fs": "^4.1.2",
                         "inherits": "~2.0.0",
@@ -33332,6 +33364,7 @@
                       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "fs.realpath": "^1.0.0",
                         "inflight": "^1.0.4",
@@ -33345,7 +33378,8 @@
                       "version": "4.1.11",
                       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
                       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "har-schema": {
                       "version": "1.0.5",
@@ -33389,7 +33423,8 @@
                       "version": "2.16.3",
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "http-signature": {
                       "version": "1.1.1",
@@ -33408,6 +33443,7 @@
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "once": "^1.3.0",
                         "wrappy": "1"
@@ -33417,7 +33453,8 @@
                       "version": "2.0.3",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "ini": {
                       "version": "1.3.4",
@@ -33431,6 +33468,7 @@
                       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "number-is-nan": "^1.0.0"
                       }
@@ -33446,7 +33484,8 @@
                       "version": "1.0.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "isstream": {
                       "version": "0.1.2",
@@ -33529,13 +33568,15 @@
                       "version": "1.27.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
                       "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "mime-types": {
                       "version": "2.1.15",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
                       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "mime-db": "~1.27.0"
                       }
@@ -33545,6 +33586,7 @@
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "brace-expansion": "^1.1.7"
                       }
@@ -33553,13 +33595,15 @@
                       "version": "0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "mkdirp": {
                       "version": "0.5.1",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "minimist": "0.0.8"
                       }
@@ -33624,7 +33668,8 @@
                       "version": "1.0.1",
                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "oauth-sign": {
                       "version": "0.8.2",
@@ -33645,6 +33690,7 @@
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "wrappy": "1"
                       }
@@ -33678,7 +33724,8 @@
                       "version": "1.0.1",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "performance-now": {
                       "version": "0.2.0",
@@ -33691,7 +33738,8 @@
                       "version": "1.0.7",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "punycode": {
                       "version": "1.4.1",
@@ -33734,6 +33782,7 @@
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
                       "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "buffer-shims": "~1.0.0",
                         "core-util-is": "~1.0.0",
@@ -33780,6 +33829,7 @@
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
                       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "glob": "^7.0.5"
                       }
@@ -33788,7 +33838,8 @@
                       "version": "5.0.1",
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
                       "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "semver": {
                       "version": "5.3.0",
@@ -33853,6 +33904,7 @@
                       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -33864,6 +33916,7 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
                       "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "safe-buffer": "^5.0.1"
                       }
@@ -33880,6 +33933,7 @@
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "ansi-regex": "^2.0.0"
                       }
@@ -33896,6 +33950,7 @@
                       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
                       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
                       "dev": true,
+                      "optional": true,
                       "requires": {
                         "block-stream": "*",
                         "fstream": "^1.0.2",
@@ -33957,7 +34012,8 @@
                       "version": "1.0.2",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     },
                     "uuid": {
                       "version": "3.0.1",
@@ -33990,7 +34046,8 @@
                       "version": "1.0.2",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                      "dev": true
+                      "dev": true,
+                      "optional": true
                     }
                   }
                 },
@@ -35341,7 +35398,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -35355,12 +35412,6 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
@@ -35368,9 +35419,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {

--- a/src/containers/views/PageEdit.js
+++ b/src/containers/views/PageEdit.js
@@ -14,7 +14,7 @@ import InputPath from '../../components/form/InputPath';
 import InputTitle from '../../components/form/InputTitle';
 import MarkdownEditor from '../../components/MarkdownEditor';
 import Metadata from '../MetaFields';
-import { fetchPage, deletePage, putPage } from '../../ducks/pages';
+import { fetchPage, deletePage, putPage, publishPage } from '../../ducks/pages';
 import { updateTitle, updateBody, updatePath } from '../../ducks/metadata';
 import { clearErrors } from '../../ducks/utils';
 import { injectDefaultFields } from '../../utils/metadata';
@@ -65,15 +65,25 @@ export class PageEdit extends Component {
   };
 
   handleClickDelete(name) {
-    const { deletePage, params } = this.props;
+    const { deletePage, publishPage, page, params } = this.props;
+    const path = page.path;
     const confirm = window.confirm(getDeleteMessage(name));
     if (confirm) {
       const [directory, ...rest] = params.splat;
       const filename = rest.join('.');
-      deletePage(directory, filename);
+      deletePage(directory, filename).then(() => {
+        publishPage(path);
+      });
       browserHistory.push(`${ADMIN_PREFIX}/pages/${directory || ''}`);
     }
   }
+
+  handleClickPublish = e => {
+    preventDefault(e);
+    const { publishPage, page } = this.props;
+    const path = page.path;
+    publishPage(path);
+  };
 
   render() {
     const {
@@ -151,19 +161,28 @@ export class PageEdit extends Component {
                 icon="save"
                 block
               />
-              <Button
-                to={http_url}
-                type="view"
-                icon="eye"
-                active={true}
-                block
-              />
+              {http_url && (
+                <Button
+                  to={http_url}
+                  type="view"
+                  icon="eye"
+                  active={true}
+                  block
+                />
+              )}
               <Splitter />
               <Button
                 onClick={() => this.handleClickDelete(name)}
                 type="delete"
                 active={true}
                 icon="trash"
+                block
+              />
+              <Button
+                onClick={this.handleClickPublish}
+                type="publish"
+                active={true}
+                icon="upload"
                 block
               />
             </div>
@@ -178,6 +197,7 @@ PageEdit.propTypes = {
   page: PropTypes.object.isRequired,
   fetchPage: PropTypes.func.isRequired,
   deletePage: PropTypes.func.isRequired,
+  publishPage: PropTypes.func.isRequired,
   putPage: PropTypes.func.isRequired,
   updateTitle: PropTypes.func.isRequired,
   updateBody: PropTypes.func.isRequired,
@@ -207,6 +227,7 @@ const mapDispatchToProps = dispatch =>
     {
       fetchPage,
       deletePage,
+      publishPage,
       putPage,
       updateTitle,
       updateBody,

--- a/src/ducks/pages.js
+++ b/src/ducks/pages.js
@@ -3,7 +3,7 @@ import { CLEAR_ERRORS, validationError } from './utils';
 import { get, put } from '../utils/fetch';
 import { validator } from '../utils/validation';
 import { slugify, trimObject } from '../utils/helpers';
-import { pagesAPIUrl, pageAPIUrl } from '../constants/api';
+import { pagesAPIUrl, pageAPIUrl, versionsPublishAPIUrl } from '../constants/api';
 import {
   getTitleRequiredMessage,
   getFilenameNotValidMessage,
@@ -119,6 +119,15 @@ export const deletePage = (directory, filename) => dispatch => {
         error,
       })
     );
+};
+
+export const publishPage = (path) => (dispatch, getState) => {
+  return get(
+    versionsPublishAPIUrl(path),
+    { type: DELETE_PAGE_SUCCESS },
+    { type: DELETE_PAGE_SUCCESS },
+    dispatch
+  );
 };
 
 const validatePage = metadata =>


### PR DESCRIPTION
This PR introduces a `Publish` button to content under the Pages tab of the staging marketing Web site, so that users can push these to the main site in the same way as for pages under the Documents tab. It's mostly a clone of the very changes that enabled that functionality in documents.

I have taken the opportunity to copy the deletion functionality as well so that one class of deletion failure is resolved (RD-2098). Previously, deletion from the pages tab would not automatically republish the site so pages would disappear from staging but still be "live" on the main site. There is a second problem with deletion still under investigation, that looks like a race condition between `jekyll-admin` threads.

I have increased the amount of (hopefully useful) information in the `README.md` for future developers.

Closes RD-2097. Contributes to RD-2098.